### PR TITLE
Issues with signing/validating request headers marked with ;req and response code @status

### DIFF
--- a/src/HttpMessageSigner.php
+++ b/src/HttpMessageSigner.php
@@ -279,15 +279,15 @@ class HttpMessageSigner
         }
 
         $whichRequest = $interface;
+        $whichHeaders = $headers;
         if (isset($parameters['req'])) {
             if ($interface instanceof ResponseInterface) {
                 $whichRequest = $this->getOriginalRequest();
-            }
-            else {
+                $whichHeaders = $this->getHeaders($whichRequest);
+            } else {
                 throw new UnProcessableSignatureException('missing request for req parameter');
             }
         }
-        $whichHeaders = $headers;
 
         if (isset($parameters['tr'])) {
             $whichHeaders = $whichRequest->getTrailers();
@@ -347,6 +347,10 @@ class HttpMessageSigner
                 default => ['"' . $fieldName . '"', trim($headers[$fieldName] ?? '')],
             };
         }
+
+        if(isset($parameters['req']))
+            $value[0] .= ';req';
+
         return $value;
     }
 

--- a/src/HttpMessageSigner.php
+++ b/src/HttpMessageSigner.php
@@ -343,7 +343,7 @@ class HttpMessageSigner
         else {
             $value = match ($fieldName) {
                 '@signature-params' => ['', ''],
-                '@status' => ['"@status"', '"@status": ' . $interface->getStatusCode()],
+                '@status' => ['"@status"', $interface->getStatusCode()],
                 default => ['"' . $fieldName . '"', trim($headers[$fieldName] ?? '')],
             };
         }


### PR DESCRIPTION
There seem to be some issues with generating a signature base for signing an HTTP response. For example @status is not working correctly, and the selected headers from the request were not included. While I'm not entirely sure that I have resolved all issues with compliance to RFC 9421, the signing and validation now seem to be somewhat more functional. Feedback is appreciated.

An example directly from the RFC which caused problems in the signature base with missing values:
```POST /foo?param=Value&Pet=dog HTTP/1.1
Host: example.com
Date: Tue, 20 Apr 2021 02:07:55 GMT
Content-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+T\
  aPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:
Content-Type: application/json
Content-Length: 18
Signature-Input: sig1=("@method" "@authority" "@path" "@query" \
  "content-digest" "content-type" "content-length")\
  ;created=1618884475;keyid="test-key-rsa-pss"
Signature: sig1=:e8UJ5wMiRaonlth5ERtE8GIiEH7Akcr493nQ07VPNo6y3qvjdK\
  t0fo8VHO8xXDjmtYoatGYBGJVlMfIp06eVMEyNW2I4vN7XDAz7m5v1108vGzaDljr\
  d0H8+SJ28g7bzn6h2xeL/8q+qUwahWA/JmC8aOC9iVnwbOKCc0WSrLgWQwTY6VLp4\
  2Qt7jjhYT5W7/wCvfK9A1VmHH1lJXsV873Z6hpxesd50PSmO+xaNeYvDLvVdZlhtw\
  5PCtUYzKjHqwmaQ6DEuM8udRjYsoNqp2xZKcuCO1nKc0V3RjpqMZLuuyVbHDAbCzr\
  0pg2d2VM/OC33JAU7meEjjaNz+d7LWPg==:

{"hello": "world"}

The server could choose to sign portions of this response, including several portions of the request, resulting in this signature base:

NOTE: '\' line wrapping per RFC 8792

"@status": 503
"content-digest": sha-512=:0Y6iCBzGg5rZtoXS95Ijz03mslf6KAMCloESHObf\
  wnHJDbkkWWQz6PhhU9kxsTbARtY2PTBOzq24uJFpHsMuAg==:
"content-type": application/json
"@authority";req: example.com
"@method";req: POST
"@path";req: /foo
"@query";req: ?param=Value&Pet=dog
"content-digest";req: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A\
  2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:
"content-type";req: application/json
"content-length";req: 18
"@signature-params": ("@status" "content-digest" "content-type" \
  "@authority";req "@method";req "@path";req "@query";req \
  "content-digest";req "content-type";req "content-length";req)\
  ;created=1618884479;keyid="test-key-ecc-p256"
```