### PR TITLE
Fix PHP 8.4 deprecation.

### DIFF
--- a/src/HttpMessageSigner.php
+++ b/src/HttpMessageSigner.php
@@ -58,7 +58,7 @@ class HttpMessageSigner
      * @throws UnProcessableSignatureException
      */
 
-    public function signRequest(string $coveredFields, MessageInterface $interface, RequestInterface $originalRequest = null): MessageInterface
+    public function signRequest(string $coveredFields, MessageInterface $interface, ?RequestInterface $originalRequest = null): MessageInterface
     {
         $headers = $this->getHeaders($interface);
         if ($originalRequest) {
@@ -86,7 +86,7 @@ class HttpMessageSigner
      * @throws UnProcessableSignatureException
      */
 
-    public function verifyRequest(MessageInterface $interface, RequestInterface $originalRequest = null): bool
+    public function verifyRequest(MessageInterface $interface, ?RequestInterface $originalRequest = null): bool
     {
         $headers = [];
         if ($originalRequest) {


### PR DESCRIPTION
Since PHP 8.4 implicit null types are deprecated:

PHP Deprecated:  HttpSignature\HttpMessageSigner::signRequest(): Implicitly marking parameter $originalRequest as nullable is deprecated, the explicit nullable type must be used instead in http-message-signer-fork/src/HttpMessageSigner.php on line 61
PHP Deprecated:  HttpSignature\HttpMessageSigner::verifyRequest(): Implicitly marking parameter $originalRequest as nullable is deprecated, the explicit nullable type must be used instead in http-message-signer-fork/src/HttpMessageSigner.php on line 89

Fix is to just explicitly mark the parameters as nullable.